### PR TITLE
Fixing issue with uninstall #57

### DIFF
--- a/src/VersionsCheckPlugin.php
+++ b/src/VersionsCheckPlugin.php
@@ -45,6 +45,15 @@ final class VersionsCheckPlugin implements PluginInterface, EventSubscriberInter
 
     /** @var boolean */
     private $disabled = false;
+    
+    /**
+     * @var array
+     */
+    private $classes = array(
+        "SLLH\ComposerVersionsCheck\VersionsCheckPlugin",
+        "SLLH\ComposerVersionsCheck\VersionsCheck",
+        "SLLH\ComposerVersionsCheck\OutdatedPackage"
+    );
 
     /**
      * {@inheritdoc}
@@ -52,8 +61,10 @@ final class VersionsCheckPlugin implements PluginInterface, EventSubscriberInter
     public function activate(Composer $composer, IOInterface $io)
     {
         // guard for self-update problem
-        if (__CLASS__ !== 'SLLH\ComposerVersionsCheck\OutdatedPackage\VersionsCheckPlugin') {
-            return $this->disable();
+        foreach ($this->classes as $class) {
+            if (!class_exists($class)) {
+                return $this->disable();
+            }
         }
 
         $this->composer = $composer;
@@ -82,6 +93,10 @@ final class VersionsCheckPlugin implements PluginInterface, EventSubscriberInter
      */
     public function command(CommandEvent $event)
     {
+        if ($this->disabled) {
+            return;
+        }
+        
         $input = $event->getInput();
         $this->preferLowest = $input->hasOption('prefer-lowest') && true === $input->getOption('prefer-lowest');
     }

--- a/tests/OutdatedPackageTest.php
+++ b/tests/OutdatedPackageTest.php
@@ -15,9 +15,9 @@ class OutdatedPackageTest extends \PHPUnit_Framework_TestCase
         $actual = new Package('foo/bar', '1.0.0', 'v1.0.0');
         $last = new Package('foo/bar', '2.4.3', 'v2.4.3');
         $links = array(
-            $this->getMock('Composer\Package\PackageInterface'),
-            $this->getMock('Composer\Package\PackageInterface'),
-            $this->getMock('Composer\Package\PackageInterface'),
+            $this->createMock('Composer\Package\PackageInterface'),
+            $this->createMock('Composer\Package\PackageInterface'),
+            $this->createMock('Composer\Package\PackageInterface'),
         );
 
         $outdatedPackage = new OutdatedPackage($actual, $last, $links);

--- a/tests/VersionsCheckPluginTest.php
+++ b/tests/VersionsCheckPluginTest.php
@@ -47,7 +47,7 @@ class VersionsCheckPluginTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->io = new BufferIO();
-        $this->composer = $this->getMock('Composer\Composer');
+        $this->composer = $this->createMock('Composer\Composer');
         $this->config = new Config(false);
 
         $this->composer->expects($this->any())->method('getConfig')


### PR DESCRIPTION
Checking if classes exist and if they do not, disables the methods from running. This allows a clean uninstall. 