### PR TITLE
Add configuration option to limit by vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ You can configure the plugin via the [`COMPOSER_HOME/config.json`](https://getco
 {
     "config": {
         "sllh-composer-versions-check": {
-            "show-links": false
+            "show-links": false,
+            "vendor": "drupal"
         }
     }
 }
 ```
 
 * `show-links`: Shows outdated package links. Set to `true` to get a larger output, like the demo.
+* `vendor`: Limits the output to a specific vendor/provider.

--- a/src/VersionsCheck.php
+++ b/src/VersionsCheck.php
@@ -27,7 +27,7 @@ final class VersionsCheck
      * @param WritableRepositoryInterface $localRepository
      * @param RootPackageInterface        $rootPackage
      */
-    public function checkPackages(ArrayRepository $distRepository, WritableRepositoryInterface $localRepository, RootPackageInterface $rootPackage)
+    public function checkPackages(ArrayRepository $distRepository, WritableRepositoryInterface $localRepository, RootPackageInterface $rootPackage, $vendorName)
     {
         $packages = $localRepository->getPackages();
         foreach ($packages as $package) {
@@ -41,6 +41,12 @@ final class VersionsCheck
                 ? new Constraint('>', $package->getVersion())
                 : new VersionConstraint('>', $package->getVersion())
             ;
+            if ($vendorName !== FALSE) {
+                $parts = explode('/', $package->getName());
+                if ($parts[0] !== $vendorName) {
+                    continue;
+                }
+            }
 
             $higherPackages = $distRepository->findPackages($package->getName(), $versionConstraint);
 

--- a/src/VersionsCheckPlugin.php
+++ b/src/VersionsCheckPlugin.php
@@ -87,7 +87,7 @@ final class VersionsCheckPlugin implements PluginInterface, EventSubscriberInter
             return;
         }
 
-        $this->checkVersions($this->composer->getRepositoryManager(), $this->composer->getPackage());
+        $this->checkVersions($this->composer->getRepositoryManager(), $this->composer->getPackage(), $this->options);
     }
 
     /**
@@ -104,6 +104,7 @@ final class VersionsCheckPlugin implements PluginInterface, EventSubscriberInter
 
         $options = array(
             'show-links' => false,
+            'vendor' => FALSE,
         );
 
         if (null === $pluginConfig) {
@@ -111,6 +112,7 @@ final class VersionsCheckPlugin implements PluginInterface, EventSubscriberInter
         }
 
         $options['show-links'] = isset($pluginConfig['show-links']) ? (bool) $pluginConfig['show-links'] : $options['show-links'];
+        $options['vendor'] = isset($pluginConfig['vendor']) ? $pluginConfig['vendor'] : FALSE;
 
         return $options;
     }
@@ -121,11 +123,13 @@ final class VersionsCheckPlugin implements PluginInterface, EventSubscriberInter
      */
     private function checkVersions(RepositoryManager $repositoryManager, RootPackageInterface $rootPackage)
     {
+        $vendorName = $this->options['vendor'] ?? FALSE;
         foreach ($repositoryManager->getRepositories() as $repository) {
             $this->versionsCheck->checkPackages(
                 $repository,
                 $repositoryManager->getLocalRepository(),
-                $rootPackage
+                $rootPackage,
+                $vendorName
             );
         }
 


### PR DESCRIPTION
## Purpose/motivation
In some instances, developers may only be interested in seeing version differences for a specific vendor. In the case of, say, the Drupal or Wordpress frameworks, it would be useful to see only the update versions available for the contributed modules/plugins, and ignoring the Symfony dependencies.

## Proposed resolution
Add a local repository configuration option that allows specifying a vendor name. If present, filter results by that name.

## Testing steps
Run composer install using a composer.json like the following:

```
{
    "name": "markfullmer/test",
    "type": "library",
    "require": {
        "drupal/pathauto": "1.6-beta1"
    },
    "config": {
        "sllh-composer-versions-check": {
            "vendor": "drupal"
        }
    },
    "repositories": {
        "drupal": {
            "type": "composer",
            "url": "https://packages.drupal.org/8"
        }
    }
}
```

When the `"vendor": "drupal" configuration option is present, the output from this plugin should be limited to 

```
1 package is not up to date:

  - drupal/pathauto (1.6.0-beta1) latest is 1.6.0
```