### PR TITLE
Add support for Composer version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     ],
     "require": {
         "php": "^5.3 || ^7.0",
-        "composer-plugin-api": "^1.0"
+        "composer-plugin-api": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "composer/composer": "^1.0",
+        "composer/composer": "^1.0 || ^2.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "symfony/phpunit-bridge": "^2.7.4|^3.0"
     },

--- a/src/VersionsCheckPlugin.php
+++ b/src/VersionsCheckPlugin.php
@@ -131,4 +131,20 @@ final class VersionsCheckPlugin implements PluginInterface, EventSubscriberInter
 
         $this->io->write($this->versionsCheck->getOutput($this->options['show-links']), false);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+
+    }
 }


### PR DESCRIPTION
Composer version 2 has `composer-plugin-api` version 2. This PR updates the version constraint to `^1 || ^2` so we can support both composer versions.

See [What's new in Composer 2](https://php.watch/articles/composer-2) and [UPGRADE-2.0](https://github.com/composer/composer/blob/master/UPGRADE-2.0.md#for-integrators-and-plugin-authors) for more changes in API. Empty methods \SLLH\ComposerVersionsCheck\VersionsCheckPlugin::deactivate() and \SLLH\ComposerVersionsCheck\VersionsCheckPlugin::uninstall() are added to make it compatible both versions.

Related discussion in composer/composer#8726.