### PR TITLE
Add option to ignore sub dependencies checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ You can configure the plugin via the [`COMPOSER_HOME/config.json`](https://getco
 {
     "config": {
         "sllh-composer-versions-check": {
+            "ignore-sub-dependencies": false,
             "show-links": false
         }
     }
 }
 ```
 
+* `ignore-sub-dependencies`: Shows only outdated package required in composer.json.
 * `show-links`: Shows outdated package links. Set to `true` to get a larger output, like the demo.

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ You can configure the plugin via the [`COMPOSER_HOME/config.json`](https://getco
 {
     "config": {
         "sllh-composer-versions-check": {
-            "ignore-sub-dependencies": false,
+            "root-packages-only": false,
             "show-links": false
         }
     }
 }
 ```
 
-* `ignore-sub-dependencies`: Shows only outdated package required in composer.json.
+* `ignore-sub-dependencies`: Shows only outdated root packages.
 * `show-links`: Shows outdated package links. Set to `true` to get a larger output, like the demo.

--- a/src/VersionsCheck.php
+++ b/src/VersionsCheck.php
@@ -34,7 +34,7 @@ final class VersionsCheck
             }
 
             // Sub dependencies are ignored and package is not require in root. Skip.
-            if ($ignoreSubDependencies && !in_array($package->getName(), $rootRequires, true)) {
+            if ($ignoreSubDependencies && !\in_array($package->getName(), $rootRequires, true)) {
                 continue;
             }
 

--- a/src/VersionsCheck.php
+++ b/src/VersionsCheck.php
@@ -22,7 +22,7 @@ final class VersionsCheck
      */
     private $outdatedPackages = array();
 
-    public function checkPackages(ArrayRepository $distRepository, WritableRepositoryInterface $localRepository, RootPackageInterface $rootPackage, bool $ignoreSubDependencies)
+    public function checkPackages(ArrayRepository $distRepository, WritableRepositoryInterface $localRepository, RootPackageInterface $rootPackage, $ignoreSubDependencies)
     {
         $packages = $localRepository->getPackages();
         $rootRequires = array_keys($rootPackage->getRequires()) + array_keys($rootPackage->getDevRequires());

--- a/src/VersionsCheck.php
+++ b/src/VersionsCheck.php
@@ -22,7 +22,7 @@ final class VersionsCheck
      */
     private $outdatedPackages = array();
 
-    public function checkPackages(ArrayRepository $distRepository, WritableRepositoryInterface $localRepository, RootPackageInterface $rootPackage, $ignoreSubDependencies)
+    public function checkPackages(ArrayRepository $distRepository, WritableRepositoryInterface $localRepository, RootPackageInterface $rootPackage, $rootPackagesOnly)
     {
         $packages = $localRepository->getPackages();
         $rootRequires = array_keys($rootPackage->getRequires() + $rootPackage->getDevRequires());
@@ -33,8 +33,8 @@ final class VersionsCheck
                 continue;
             }
 
-            // Sub dependencies are ignored and package is not require in root. Skip.
-            if ($ignoreSubDependencies && !\in_array($package->getName(), $rootRequires, true)) {
+            // No root package are ignored and it is one. Skip.
+            if ($rootPackagesOnly && !\in_array($package->getName(), $rootRequires, true)) {
                 continue;
             }
 

--- a/src/VersionsCheck.php
+++ b/src/VersionsCheck.php
@@ -25,7 +25,7 @@ final class VersionsCheck
     public function checkPackages(ArrayRepository $distRepository, WritableRepositoryInterface $localRepository, RootPackageInterface $rootPackage, $ignoreSubDependencies)
     {
         $packages = $localRepository->getPackages();
-        $rootRequires = array_keys($rootPackage->getRequires()) + array_keys($rootPackage->getDevRequires());
+        $rootRequires = array_keys($rootPackage->getRequires() + $rootPackage->getDevRequires());
 
         foreach ($packages as $package) {
             // Do not compare aliases. Aliased packages are also provided.

--- a/src/VersionsCheck.php
+++ b/src/VersionsCheck.php
@@ -22,12 +22,19 @@ final class VersionsCheck
      */
     private $outdatedPackages = array();
 
-    public function checkPackages(ArrayRepository $distRepository, WritableRepositoryInterface $localRepository, RootPackageInterface $rootPackage)
+    public function checkPackages(ArrayRepository $distRepository, WritableRepositoryInterface $localRepository, RootPackageInterface $rootPackage, bool $ignoreSubDependencies)
     {
         $packages = $localRepository->getPackages();
+        $rootRequires = array_keys($rootPackage->getRequires()) + array_keys($rootPackage->getDevRequires());
+
         foreach ($packages as $package) {
             // Do not compare aliases. Aliased packages are also provided.
             if ($package instanceof AliasPackage) {
+                continue;
+            }
+
+            // Sub dependencies are ignored and package is not require in root. Skip.
+            if ($ignoreSubDependencies && !in_array($package->getName(), $rootRequires, true)) {
                 continue;
             }
 

--- a/src/VersionsCheckPlugin.php
+++ b/src/VersionsCheckPlugin.php
@@ -111,7 +111,7 @@ final class VersionsCheckPlugin implements PluginInterface, EventSubscriberInter
         ;
 
         $options = array(
-            'ignore-sub-dependencies' => false,
+            'root-packages-only' => false,
             'show-links' => false,
         );
 
@@ -119,7 +119,7 @@ final class VersionsCheckPlugin implements PluginInterface, EventSubscriberInter
             return $options;
         }
 
-        $options['ignore-sub-dependencies'] = isset($pluginConfig['ignore-sub-dependencies']) ? (bool) $pluginConfig['ignore-sub-dependencies'] : $options['ignore-sub-dependencies'];
+        $options['root-packages-only'] = isset($pluginConfig['root-packages-only']) ? (bool) $pluginConfig['root-packages-only'] : $options['root-packages-only'];
         $options['show-links'] = isset($pluginConfig['show-links']) ? (bool) $pluginConfig['show-links'] : $options['show-links'];
 
         return $options;
@@ -132,7 +132,7 @@ final class VersionsCheckPlugin implements PluginInterface, EventSubscriberInter
                 $repository,
                 $repositoryManager->getLocalRepository(),
                 $rootPackage,
-                $this->options['ignore-sub-dependencies']
+                $this->options['root-packages-only']
             );
         }
 

--- a/src/VersionsCheckPlugin.php
+++ b/src/VersionsCheckPlugin.php
@@ -111,6 +111,7 @@ final class VersionsCheckPlugin implements PluginInterface, EventSubscriberInter
         ;
 
         $options = array(
+            'ignore-sub-dependencies' => false,
             'show-links' => false,
         );
 
@@ -118,6 +119,7 @@ final class VersionsCheckPlugin implements PluginInterface, EventSubscriberInter
             return $options;
         }
 
+        $options['ignore-sub-dependencies'] = isset($pluginConfig['ignore-sub-dependencies']) ? (bool) $pluginConfig['ignore-sub-dependencies'] : $options['ignore-sub-dependencies'];
         $options['show-links'] = isset($pluginConfig['show-links']) ? (bool) $pluginConfig['show-links'] : $options['show-links'];
 
         return $options;
@@ -129,7 +131,8 @@ final class VersionsCheckPlugin implements PluginInterface, EventSubscriberInter
             $this->versionsCheck->checkPackages(
                 $repository,
                 $repositoryManager->getLocalRepository(),
-                $rootPackage
+                $rootPackage,
+                $this->options['ignore-sub-dependencies']
             );
         }
 

--- a/tests/VersionsCheckPluginTest.php
+++ b/tests/VersionsCheckPluginTest.php
@@ -94,12 +94,14 @@ class VersionsCheckPluginTest extends \PHPUnit_Framework_TestCase
             'No option' => array(
                 null,
                 array(
+                    'ignore-sub-dependencies' => false,
                     'show-links' => false,
                 ),
             ),
             'Empty array options' => array(
                 array(),
                 array(
+                    'ignore-sub-dependencies' => false,
                     'show-links' => false,
                 ),
             ),
@@ -110,6 +112,7 @@ class VersionsCheckPluginTest extends \PHPUnit_Framework_TestCase
                     ),
                 ),
                 array(
+                    'ignore-sub-dependencies' => false,
                     'show-links' => false,
                 ),
             ),
@@ -120,6 +123,7 @@ class VersionsCheckPluginTest extends \PHPUnit_Framework_TestCase
                     ),
                 ),
                 array(
+                    'ignore-sub-dependencies' => false,
                     'show-links' => false,
                 ),
             ),
@@ -130,6 +134,33 @@ class VersionsCheckPluginTest extends \PHPUnit_Framework_TestCase
                     ),
                 ),
                 array(
+                    'ignore-sub-dependencies' => false,
+                    'show-links' => false,
+                ),
+            ),
+            'Activate ignore-sub-dependencies' => array(
+                array(
+                    'config' => array(
+                        'sllh-composer-versions-check' => array(
+                            'ignore-sub-dependencies' => true,
+                        ),
+                    ),
+                ),
+                array(
+                    'ignore-sub-dependencies' => true,
+                    'show-links' => false,
+                ),
+            ),
+            'Disable ignore-sub-dependencies' => array(
+                array(
+                    'config' => array(
+                        'sllh-composer-versions-check' => array(
+                            'ignore-sub-dependencies' => false,
+                        ),
+                    ),
+                ),
+                array(
+                    'ignore-sub-dependencies' => false,
                     'show-links' => false,
                 ),
             ),
@@ -142,6 +173,7 @@ class VersionsCheckPluginTest extends \PHPUnit_Framework_TestCase
                     ),
                 ),
                 array(
+                    'ignore-sub-dependencies' => false,
                     'show-links' => true,
                 ),
             ),
@@ -154,6 +186,7 @@ class VersionsCheckPluginTest extends \PHPUnit_Framework_TestCase
                     ),
                 ),
                 array(
+                    'ignore-sub-dependencies' => false,
                     'show-links' => false,
                 ),
             ),

--- a/tests/VersionsCheckPluginTest.php
+++ b/tests/VersionsCheckPluginTest.php
@@ -94,14 +94,14 @@ class VersionsCheckPluginTest extends \PHPUnit_Framework_TestCase
             'No option' => array(
                 null,
                 array(
-                    'ignore-sub-dependencies' => false,
+                    'root-packages-only' => false,
                     'show-links' => false,
                 ),
             ),
             'Empty array options' => array(
                 array(),
                 array(
-                    'ignore-sub-dependencies' => false,
+                    'root-packages-only' => false,
                     'show-links' => false,
                 ),
             ),
@@ -112,7 +112,7 @@ class VersionsCheckPluginTest extends \PHPUnit_Framework_TestCase
                     ),
                 ),
                 array(
-                    'ignore-sub-dependencies' => false,
+                    'root-packages-only' => false,
                     'show-links' => false,
                 ),
             ),
@@ -123,7 +123,7 @@ class VersionsCheckPluginTest extends \PHPUnit_Framework_TestCase
                     ),
                 ),
                 array(
-                    'ignore-sub-dependencies' => false,
+                    'root-packages-only' => false,
                     'show-links' => false,
                 ),
             ),
@@ -134,33 +134,33 @@ class VersionsCheckPluginTest extends \PHPUnit_Framework_TestCase
                     ),
                 ),
                 array(
-                    'ignore-sub-dependencies' => false,
+                    'root-packages-only' => false,
                     'show-links' => false,
                 ),
             ),
-            'Activate ignore-sub-dependencies' => array(
+            'Activate root-packages-only' => array(
                 array(
                     'config' => array(
                         'sllh-composer-versions-check' => array(
-                            'ignore-sub-dependencies' => true,
+                            'root-packages-only' => true,
                         ),
                     ),
                 ),
                 array(
-                    'ignore-sub-dependencies' => true,
+                    'root-packages-only' => true,
                     'show-links' => false,
                 ),
             ),
-            'Disable ignore-sub-dependencies' => array(
+            'Disable root-packages-only' => array(
                 array(
                     'config' => array(
                         'sllh-composer-versions-check' => array(
-                            'ignore-sub-dependencies' => false,
+                            'root-packages-only' => false,
                         ),
                     ),
                 ),
                 array(
-                    'ignore-sub-dependencies' => false,
+                    'root-packages-only' => false,
                     'show-links' => false,
                 ),
             ),
@@ -173,7 +173,7 @@ class VersionsCheckPluginTest extends \PHPUnit_Framework_TestCase
                     ),
                 ),
                 array(
-                    'ignore-sub-dependencies' => false,
+                    'root-packages-only' => false,
                     'show-links' => true,
                 ),
             ),
@@ -186,7 +186,7 @@ class VersionsCheckPluginTest extends \PHPUnit_Framework_TestCase
                     ),
                 ),
                 array(
-                    'ignore-sub-dependencies' => false,
+                    'root-packages-only' => false,
                     'show-links' => false,
                 ),
             ),

--- a/tests/VersionsCheckTest.php
+++ b/tests/VersionsCheckTest.php
@@ -207,6 +207,6 @@ EOF
      */
     private function checkPackages()
     {
-        $this->versionsCheck->checkPackages($this->distRepository, $this->localRepository, $this->rootPackage);
+        $this->versionsCheck->checkPackages($this->distRepository, $this->localRepository, $this->rootPackage, false);
     }
 }

--- a/tests/VersionsCheckTest.php
+++ b/tests/VersionsCheckTest.php
@@ -203,10 +203,83 @@ EOF
     }
 
     /**
+     * @dataProvider getRootOnlyPackageTestsData
+     */
+    public function testRootOnlyPackage(array $packagesData, array $packagesRequired, array $packagesDevRequired, $rootOnly, $outdatedPackagesCount)
+    {
+
+        foreach ($packagesData as $name => $packageData) {
+            list($actualVersion, $availableVersions, $expectedVersion) = $packageData;
+            $this->localRepository->addPackage(new Package($name, $actualVersion, $actualVersion));
+            foreach ($availableVersions as $availableVersion) {
+                $this->distRepository->addPackage(new Package($name, $availableVersion, $availableVersion));
+            }
+
+            if (false !== $expectedVersion) {
+                $shouldBeUpdatedOutput[] = sprintf(
+                    '  - <info>%s</info> (<comment>%s</comment>) latest is <comment>%s</comment>',
+                    $name, $actualVersion, $expectedVersion
+                );
+            }
+        }
+
+        $this->rootPackage->setRequires($packagesRequired);
+        $this->rootPackage->setDevRequires($packagesDevRequired);
+
+        $this->checkPackages($rootOnly);
+
+        $this->assertSame(sprintf(<<<'EOF'
+<warning>%d packages are not up to date:</warning>
+
+%s
+
+
+EOF
+            , $outdatedPackagesCount, implode("\n\n", $shouldBeUpdatedOutput)), $this->versionsCheck->getOutput());
+    }
+
+    /**
+     * @return array
+     */
+    public function getRootOnlyPackageTestsData()
+    {
+        return array(
+            array(array(
+                'foo/bar' => array('1.0.0', array('1.0.0', '1.0.1', '1.0.2', '1.0.4', '2.0.0'), '2.0.0'),
+                'some/package' => array('1.0.4', array('1.0.0', '1.0.1', '1.0.2', '1.0.4', '2.0.0'), false),
+                'vendor/package-1' => array('2.0.0', array('1.0.0', '1.0.1', '1.0.2', '1.0.4', '2.0.0'), false),
+                'vendor/up-to-date' => array('9.9.0', array('8.0.0', '9.9.0', '1.0-dev'), false),
+                'vendor/dev-master' => array('9.9.0', array('8.0.0', '9.9.0', '10.0-dev'), false),
+                'vendor/package-2' => array('1.0.0', array('1.0.0', '1.0.1', '2.0.0', '2.0.0-alpha1'), '2.0.0'),
+                'vendor/package-3' => array('1.0.1', array('1.0.0', '1.0.1', '2.0.0-alpha1'), false),
+                'vendor/prefer-stable' => array('1.0.1', array('1.0.0', '1.0.1', '2.0.0-alpha1'), false),
+            ), array(
+                'foo/bar' => new Link('foo/bar', 'foo/bar')
+            ), array(
+                'vendor/package-2' => new Link('vendor/package-2', 'vendor/package-2')
+            ), true, 2),
+            array(array(
+                'foo/bar' => array('1.0.0', array('1.0.0', '1.0.1', '1.0.2', '1.0.4', '2.0.0'), '2.0.0'),
+                'some/package' => array('1.0.4', array('1.0.0', '1.0.1', '1.0.2', '1.0.4', '2.0.0'), '2.0.0'),
+                'vendor/package-1' => array('2.0.0', array('1.0.0', '1.0.1', '1.0.2', '1.0.4', '2.0.0'), false),
+                'vendor/up-to-date' => array('9.9.0', array('8.0.0', '9.9.0', '1.0-dev'), false),
+                'vendor/dev-master' => array('9.9.0', array('8.0.0', '9.9.0', '10.0-dev'), '10.0-dev'),
+                'vendor/package-2' => array('1.0.0', array('1.0.0', '1.0.1', '2.0.0', '2.0.0-alpha1'), '2.0.0'),
+                'vendor/package-3' => array('1.0.1', array('1.0.0', '1.0.1', '2.0.0-alpha1'), '2.0.0-alpha1'),
+                'vendor/prefer-stable' => array('1.0.1', array('1.0.0', '1.0.1', '2.0.0-alpha1'), '2.0.0-alpha1'),
+            ), array(
+                'foo/bar' => new Link('foo/bar', 'foo/bar')
+            ), array(
+                'vendor/package-2' => new Link('vendor/package-2', 'vendor/package-2')
+            ), false, 6),
+        );
+    }
+
+    /**
      * Calls VersionsCheck::checkPackages.
      */
-    private function checkPackages()
+    private function checkPackages($rootPackageOnly = false)
     {
-        $this->versionsCheck->checkPackages($this->distRepository, $this->localRepository, $this->rootPackage, false);
+        $this->versionsCheck->checkPackages($this->distRepository, $this->localRepository, $this->rootPackage, $rootPackageOnly);
     }
 }

--- a/tests/VersionsCheckTest.php
+++ b/tests/VersionsCheckTest.php
@@ -109,22 +109,7 @@ EOF
         $this->rootPackage->setMinimumStability('dev');
         $this->rootPackage->setPreferStable($preferStable);
 
-        $shouldBeUpdatedOutput = array();
-
-        foreach ($packagesData as $name => $packageData) {
-            list($actualVersion, $availableVersions, $expectedVersion) = $packageData;
-            $this->localRepository->addPackage(new Package($name, $actualVersion, $actualVersion));
-            foreach ($availableVersions as $availableVersion) {
-                $this->distRepository->addPackage(new Package($name, $availableVersion, $availableVersion));
-            }
-
-            if (false !== $expectedVersion) {
-                $shouldBeUpdatedOutput[] = sprintf(
-                    '  - <info>%s</info> (<comment>%s</comment>) latest is <comment>%s</comment>',
-                    $name, $actualVersion, $expectedVersion
-                );
-            }
-        }
+        $shouldBeUpdatedOutput = $this->addPackagesAndGetShouldBeUpdatedOutput($packagesData);
 
         $this->checkPackages();
 
@@ -207,22 +192,7 @@ EOF
      */
     public function testRootOnlyPackage(array $packagesData, array $packagesRequired, array $packagesDevRequired, $rootOnly, $outdatedPackagesCount)
     {
-
-        foreach ($packagesData as $name => $packageData) {
-            list($actualVersion, $availableVersions, $expectedVersion) = $packageData;
-            $this->localRepository->addPackage(new Package($name, $actualVersion, $actualVersion));
-            foreach ($availableVersions as $availableVersion) {
-                $this->distRepository->addPackage(new Package($name, $availableVersion, $availableVersion));
-            }
-
-            if (false !== $expectedVersion) {
-                $shouldBeUpdatedOutput[] = sprintf(
-                    '  - <info>%s</info> (<comment>%s</comment>) latest is <comment>%s</comment>',
-                    $name, $actualVersion, $expectedVersion
-                );
-            }
-        }
-
+        $shouldBeUpdatedOutput = $this->addPackagesAndGetShouldBeUpdatedOutput($packagesData);
         $this->rootPackage->setRequires($packagesRequired);
         $this->rootPackage->setDevRequires($packagesDevRequired);
 
@@ -254,9 +224,9 @@ EOF
                 'vendor/package-3' => array('1.0.1', array('1.0.0', '1.0.1', '2.0.0-alpha1'), false),
                 'vendor/prefer-stable' => array('1.0.1', array('1.0.0', '1.0.1', '2.0.0-alpha1'), false),
             ), array(
-                'foo/bar' => new Link('foo/bar', 'foo/bar')
+                'foo/bar' => new Link('foo/bar', 'foo/bar'),
             ), array(
-                'vendor/package-2' => new Link('vendor/package-2', 'vendor/package-2')
+                'vendor/package-2' => new Link('vendor/package-2', 'vendor/package-2'),
             ), true, 2),
             array(array(
                 'foo/bar' => array('1.0.0', array('1.0.0', '1.0.1', '1.0.2', '1.0.4', '2.0.0'), '2.0.0'),
@@ -268,11 +238,33 @@ EOF
                 'vendor/package-3' => array('1.0.1', array('1.0.0', '1.0.1', '2.0.0-alpha1'), '2.0.0-alpha1'),
                 'vendor/prefer-stable' => array('1.0.1', array('1.0.0', '1.0.1', '2.0.0-alpha1'), '2.0.0-alpha1'),
             ), array(
-                'foo/bar' => new Link('foo/bar', 'foo/bar')
+                'foo/bar' => new Link('foo/bar', 'foo/bar'),
             ), array(
-                'vendor/package-2' => new Link('vendor/package-2', 'vendor/package-2')
+                'vendor/package-2' => new Link('vendor/package-2', 'vendor/package-2'),
             ), false, 6),
         );
+    }
+
+    private function addPackagesAndGetShouldBeUpdatedOutput(array $packagesData)
+    {
+        $shouldBeUpdatedOutput = array();
+
+        foreach ($packagesData as $name => $packageData) {
+            list($actualVersion, $availableVersions, $expectedVersion) = $packageData;
+            $this->localRepository->addPackage(new Package($name, $actualVersion, $actualVersion));
+            foreach ($availableVersions as $availableVersion) {
+                $this->distRepository->addPackage(new Package($name, $availableVersion, $availableVersion));
+            }
+
+            if (false !== $expectedVersion) {
+                $shouldBeUpdatedOutput[] = sprintf(
+                    '  - <info>%s</info> (<comment>%s</comment>) latest is <comment>%s</comment>',
+                    $name, $actualVersion, $expectedVersion
+                );
+            }
+        }
+
+        return $shouldBeUpdatedOutput;
     }
 
     /**


### PR DESCRIPTION
Implement #30

Add an option `ignore-sub-dependencies` and check if a package is required in root.