### PR TITLE
Use PHP without semver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": ">=5.3",
         "composer-plugin-api": "^1.0 || ^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Allow also PHP8+, and allow adapting early on

There is no reason to use semver on PHP, it is also not recommended to do so
Symfony does this now too (again).