### PR TITLE
Fix deprecation notice in PHP 8.x

### DIFF
--- a/src/VersionsCheck.php
+++ b/src/VersionsCheck.php
@@ -50,7 +50,7 @@ final class VersionsCheck
             if (\count($higherPackages) > 0) {
                 // Sort packages by highest version to lowest
                 usort($higherPackages, function (PackageInterface $p1, PackageInterface $p2) {
-                    return Comparator::compare($p1->getVersion(), '<', $p2->getVersion());
+                    return Comparator::compare($p1->getVersion(), '<', $p2->getVersion()) ? 1 : -1;
                 });
 
                 // Push actual and last package on outdated array


### PR DESCRIPTION
According to the documentation, all versions of PHP support the `usort` callable parameter returning an `integer`. While earlier versions silently accepted a `boolean`, PHP 8.x throws a deprecation notice:

```
Deprecation Notice: usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero in C:\Users\MY_USER\AppData\Roaming\Composer\vendor\sllh\composer-versions-check\src\VersionsCheck.php:54
```

This fix (based on [this comment](https://github.com/soullivaneuh/composer-versions-check/pull/75#discussion_r532199009)) eliminates this notice.

fixes #74